### PR TITLE
Improve scaling of Like API

### DIFF
--- a/like.service.yaml
+++ b/like.service.yaml
@@ -2,6 +2,7 @@
 # https://cloud.google.com/appengine/docs/standard/python/config/appref
 runtime: nodejs14
 entrypoint: npm run start:prod
+instance_class: F2
 env_variables:
   SERVER_PORT: 8080
   PLUGINS: 'LIKE_API'
@@ -10,3 +11,8 @@ env_variables:
   RECOMMENDER_BOT_TOKEN: 'NWYyNWI4MjVjMjc0ZmRjZWI1ZWFhYmQ4M2JlMzJiNzEK'
   RECOMMENDER_BOT_USER_UUID: 'b6256195-1ac6-4146-8d75-d796447c06ad'
   LIKE_STORAGE: 'memory' # @TODO
+automatic_scaling:
+  min_instances: 1
+  max_concurrent_requests: 50
+inbound_services:
+  - warmup

--- a/src/app/app.controller.ts
+++ b/src/app/app.controller.ts
@@ -43,4 +43,10 @@ export class AppController {
   ): AuthenticatedUserEntity {
     return user;
   }
+
+  // MARK: App Engine
+  @Get('_ah/warmup')
+  warmup(): void {
+    return;
+  }
 }

--- a/test/app/app.e2e-spec.ts
+++ b/test/app/app.e2e-spec.ts
@@ -164,4 +164,8 @@ describe('AppController (e2e)', () => {
 
     expect(verifyTokenMock.isDone()).toBeTruthy();
   });
+
+  it('/_ah/warmup (GET)', () => {
+    return request(app.getHttpServer()).get('/_ah/warmup').expect(200);
+  });
 });


### PR DESCRIPTION
- Set like service instance class to F2
- Allow higher number of concurrent requests
- Require minimum of 1 active instances
- Configure warmup handler